### PR TITLE
Fixed a warning message and updated dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         </repository>
         <repository>
             <id>placeholderapi</id>
-            <url>http://repo.extendedclip.com/content/repositories/placeholderapi/</url>
+            <url>https://repo.extendedclip.com/content/repositories/placeholderapi/</url>
         </repository>
     </repositories>
     <!-- Build stuff. -->
@@ -49,7 +49,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>LATEST</version>
+                <version>3.2.4</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -77,14 +77,14 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.16</version>
+            <version>1.18.20</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <!-- PlaceHolderApi -->
             <groupId>me.clip</groupId>
             <artifactId>placeholderapi</artifactId>
-            <version>2.9.2</version>
+            <version>2.10.9</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/com/xIsm4/plugins/Main.java
+++ b/src/main/java/com/xIsm4/plugins/Main.java
@@ -25,7 +25,7 @@ public class Main extends JavaPlugin {
        saveDefaultConfig();
        commandHandler();
        this.saveConfig();
-       System.out.println("SternalBoard has been enabled");
+       getLogger().info("SternalBoard has been enabled");
        getServer().getPluginManager().registerEvents(new PlayerListener(this), this);
        instance = this;
        scoreboardManager = new ScoreboardManager(this);
@@ -34,7 +34,7 @@ public class Main extends JavaPlugin {
 
     @Override
     public void onDisable() {
-      System.out.println("Disabling [SternalBoard]");
+      getLogger().info("Disabling [SternalBoard]");
     }
 
     //Commands


### PR DESCRIPTION
- Fixed a warning message in Paper 1.17.1+
- Changed placeholderapi repository to https(Causes compile failures in recent maven versions)
- Updated dependencies