### PR TITLE
Fix: Scoreboard toggle title bug while animated is true

### DIFF
--- a/src/main/java/com/xIsm4/plugins/commands/ToggleCMD.java
+++ b/src/main/java/com/xIsm4/plugins/commands/ToggleCMD.java
@@ -37,11 +37,12 @@ public class ToggleCMD implements CommandExecutor {
                     }
                 }else{
                     SternalBoard board = new SternalBoard(player);
-                    if (core.getConfig().getInt("settings.scoreboard.update") > 0) {
-                        core.getServer().getScheduler().runTaskTimerAsynchronously(core, () -> board.updateTitle(PlaceholderUtils.sanitizeString(player, core.getConfig().getString("settings.scoreboard.title"))), 0, core.getConfig().getInt("settings.scoreboard.update", 20));
+                    core.getScoreboardManager().getBoards().put(player.getUniqueId(), board);
+
+                    if (!core.isAnimateScore() && core.getConfig().getInt("settings.scoreboard.update") == 0) {
+                        board.updateTitle(PlaceholderUtils.sanitizeString(player, core.getConfig().getString("settings.scoreboard.title")));
                     }
 
-                    core.getScoreboardManager().getBoards().put(player.getUniqueId(), board);
                     setToggle(true);
                 }
             }

--- a/src/main/java/com/xIsm4/plugins/managers/ScoreboardManager.java
+++ b/src/main/java/com/xIsm4/plugins/managers/ScoreboardManager.java
@@ -30,6 +30,11 @@ public class ScoreboardManager {
         this.core = core;
     }
 
+    //Some compilers seem to not add getBoards() on compile time, so this is how this exists now xd
+    public ConcurrentMap<UUID, SternalBoard> getBoards(){
+        return this.boards;
+    }
+
     //Update tasks > 20
     public void init() {
         taskIds = new Integer[2];


### PR DESCRIPTION
When you execute "/sbtoggle toggle" and turn the scoreboard back on, the title would switch from the animated title to the static title at least each second.

It also included the blind fix I did before when the compiler issue appeared xd